### PR TITLE
Update epub.css - Remove code/block font sizing.

### DIFF
--- a/lib/epub.css
+++ b/lib/epub.css
@@ -14,4 +14,4 @@ ol.toc { padding: 0; margin-left: 1em; }
 ol.toc li { list-style-type: none; margin: 0; padding: 0; }
 a.footnoteRef { vertical-align: super; }
 
-pre { text-align: left; white-space: pre-wrap; font-size: 0.6em; }
+pre { text-align: left; white-space: pre-wrap }


### PR DESCRIPTION
Remove code sizing so that the reader controls it.
This makes it far more legible on a Kindle for instance.