### PR TITLE
Added a Rust logo floating right on the side in gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
 <body>
     <article role="main">
         <header>
+            <img src="https://www.rust-lang.org/logos/rust-logo-blk.svg" />
             <h1>'The Rust Programming Language' E-Books</h1>
             <span id="forkongithub"><a href="https://github.com/killercup/trpl-ebook">Fork me on GitHub</a></span>
         </header>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         @media screen and (max-width:800px){
             body { margin-top: 1em;}
         }
+        img {float: right;}
         article, header, footer, aside { display: block; }
         li { margin-bottom: 0.5em; }
         footer { text-align: center; margin-top: 4em; font-size: 0.8em; }

--- a/index.html
+++ b/index.html
@@ -6,24 +6,24 @@
     <meta name="viewport" content="width=device-width"/>
     <style>
         body { max-width: 40em; margin: 6em auto 2em; font-size: 16px; font-family: sans-serif; line-height: 1.3; padding: 0.6em; }
-@media screen and (max-width:800px){
-    body { margin-top: 1em;}
-}
-article, header, footer, aside { display: block; }
-li { margin-bottom: 0.5em; }
-footer { text-align: center; margin-top: 4em; font-size: 0.8em; }
-aside { position: absolute; top: 0; right: 0; border: 0; }
-aside img { border: 0; }
-
-/* from https://codepo8.github.io/css-fork-on-github-ribbon/ */
-#forkongithub a{background:#666;color:#fff;text-decoration:none;font-family:arial,sans-serif;text-align:center;font-weight:bold;padding:5px 40px;font-size:1rem;line-height:2rem;position:relative;transition:0.2s;}
-#forkongithub a:hover{background:#000;color:#fff;}
-#forkongithub a::before,#forkongithub a::after{content:"";width:100%;display:block;position:absolute;top:1px;left:0;height:1px;background:#fff;}
-#forkongithub a::after{bottom:1px;top:auto;}
-@media screen and (min-width:800px){
-    #forkongithub{position:absolute;display:block;top:0;right:0;width:200px;overflow:hidden;height:200px;z-index:9999;}
-    #forkongithub a{width:200px;position:absolute;top:60px;right:-60px;transform:rotate(45deg);-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);-moz-transform:rotate(45deg);-o-transform:rotate(45deg);box-shadow:2px 2px 5px rgba(0,0,0,0.3);}
-}
+        @media screen and (max-width:800px){
+            body { margin-top: 1em;}
+        }
+        article, header, footer, aside { display: block; }
+        li { margin-bottom: 0.5em; }
+        footer { text-align: center; margin-top: 4em; font-size: 0.8em; }
+        aside { position: absolute; top: 0; right: 0; border: 0; }
+        aside img { border: 0; }
+        
+        /* from https://codepo8.github.io/css-fork-on-github-ribbon/ */
+        #forkongithub a{background:#666;color:#fff;text-decoration:none;font-family:arial,sans-serif;text-align:center;font-weight:bold;padding:5px 40px;font-size:1rem;line-height:2rem;position:relative;transition:0.2s;}
+        #forkongithub a:hover{background:#000;color:#fff;}
+        #forkongithub a::before,#forkongithub a::after{content:"";width:100%;display:block;position:absolute;top:1px;left:0;height:1px;background:#fff;}
+        #forkongithub a::after{bottom:1px;top:auto;}
+        @media screen and (min-width:800px){
+            #forkongithub{position:absolute;display:block;top:0;right:0;width:200px;overflow:hidden;height:200px;z-index:9999;}
+            #forkongithub a{width:200px;position:absolute;top:60px;right:-60px;transform:rotate(45deg);-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);-moz-transform:rotate(45deg);-o-transform:rotate(45deg);box-shadow:2px 2px 5px rgba(0,0,0,0.3);}
+        }
 
     </style>
 </head>
@@ -40,78 +40,90 @@ aside img { border: 0; }
             <li>
                 <a href="http://doc.rust-lang.org/nightly/nomicon/">Read the original 'The Rustonomicon' on rust-lang.org</a>
             </li>
+        
             <li>
-<h2>2016-06-02</h2>
-<ul><li><a href='nomicon-2016-06-02.a4.pdf'>NOMICON A4.PDF</a></li>
-<li><a href='nomicon-2016-06-02.epub'>NOMICON EPUB</a></li>
-<li><a href='nomicon-2016-06-02.html'>NOMICON HTML</a></li>
-<li><a href='nomicon-2016-06-02.letter.pdf'>NOMICON LETTER.PDF</a></li>
-<li><a href='nomicon-2016-06-02.md'>NOMICON MD</a></li>
-<li><a href='nomicon-2016-06-02.tex'>NOMICON TEX</a></li>
-<li><a href='trpl-2016-06-02.a4.pdf'>TRPL A4.PDF</a></li>
-<li><a href='trpl-2016-06-02.epub'>TRPL EPUB</a></li>
-<li><a href='trpl-2016-06-02.html'>TRPL HTML</a></li>
-<li><a href='trpl-2016-06-02.letter.pdf'>TRPL LETTER.PDF</a></li>
-<li><a href='trpl-2016-06-02.md'>TRPL MD</a></li>
-<li><a href='trpl-2016-06-02.tex'>TRPL TEX</a></li>
-</ul>
-</li><li>      
-<h2>2015-09-26</h2>
-<ul><li><a href='trpl-2015-09-26.a4.pdf'>TRPL A4.PDF</a></li>
-<li><a href='trpl-2015-09-26.epub'>TRPL EPUB</a></li>
-<li><a href='trpl-2015-09-26.html'>TRPL HTML</a></li>
-<li><a href='trpl-2015-09-26.letter.pdf'>TRPL LETTER.PDF</a></li>
-<li><a href='trpl-2015-09-26.md'>TRPL MD</a></li>
-<li><a href='trpl-2015-09-26.tex'>TRPL TEX</a></li>
-</ul>
-</li><li>
-<h2>2015-09-12</h2>
-<ul><li><a href='nomicon-2015-09-12.a4.pdf'>NOMICON A4.PDF</a></li>
-<li><a href='nomicon-2015-09-12.epub'>NOMICON EPUB</a></li>
-<li><a href='nomicon-2015-09-12.html'>NOMICON HTML</a></li>
-<li><a href='nomicon-2015-09-12.letter.pdf'>NOMICON LETTER.PDF</a></li>
-<li><a href='nomicon-2015-09-12.md'>NOMICON MD</a></li>
-<li><a href='nomicon-2015-09-12.tex'>NOMICON TEX</a></li>
-<li><a href='trpl-2015-09-12.a4.pdf'>TRPL A4.PDF</a></li>
-<li><a href='trpl-2015-09-12.epub'>TRPL EPUB</a></li>
-<li><a href='trpl-2015-09-12.html'>TRPL HTML</a></li>
-<li><a href='trpl-2015-09-12.letter.pdf'>TRPL LETTER.PDF</a></li>
-<li><a href='trpl-2015-09-12.md'>TRPL MD</a></li>
-<li><a href='trpl-2015-09-12.tex'>TRPL TEX</a></li>
-</ul>
-</li><li>
-<h2>2015-07-31</h2>
-<ul><li><a href='trpl-2015-07-31.a4.pdf'>TRPL A4.PDF</a></li>
-<li><a href='trpl-2015-07-31.epub'>TRPL EPUB</a></li>
-<li><a href='trpl-2015-07-31.html'>TRPL HTML</a></li>
-<li><a href='trpl-2015-07-31.letter.pdf'>TRPL LETTER.PDF</a></li>
-<li><a href='trpl-2015-07-31.md'>TRPL MD</a></li>
-<li><a href='trpl-2015-07-31.tex'>TRPL TEX</a></li>
-</ul>
-</li><li>
-<h2>2015-05-24</h2>
-<ul><li><a href='trpl-2015-05-24.a4.pdf'>TRPL A4.PDF</a></li>
-<li><a href='trpl-2015-05-24.epub'>TRPL EPUB</a></li>
-<li><a href='trpl-2015-05-24.html'>TRPL HTML</a></li>
-<li><a href='trpl-2015-05-24.letter.pdf'>TRPL LETTER.PDF</a></li>
-<li><a href='trpl-2015-05-24.md'>TRPL MD</a></li>
-<li><a href='trpl-2015-05-24.mobi'>TRPL MOBI</a></li>
-<li><a href='trpl-2015-05-24.tex'>TRPL TEX</a></li>
-</ul>
-</li><li>
-<h2>2015-05-15</h2>
-<ul><li><a href='trpl-2015-05-15.epub'>TRPL EPUB</a></li>
-<li><a href='trpl-2015-05-15.html'>TRPL HTML</a></li>
-<li><a href='trpl-2015-05-15.md'>TRPL MD</a></li>
-<li><a href='trpl-2015-05-15.mobi'>TRPL MOBI</a></li>
-</ul>
-</li><li>
-<h2>2015-05-13</h2>
-<ul><li><a href='trpl-2015-05-13.epub'>TRPL EPUB</a></li>
-<li><a href='trpl-2015-05-13.html'>TRPL HTML</a></li>
-<li><a href='trpl-2015-05-13.md'>TRPL MD</a></li>
-</ul>
-</li>
+            <h2>2016-06-02</h2>
+            <ul><li><a href='nomicon-2016-06-02.a4.pdf'>NOMICON A4.PDF</a></li>
+            <li><a href='nomicon-2016-06-02.epub'>NOMICON EPUB</a></li>
+            <li><a href='nomicon-2016-06-02.html'>NOMICON HTML</a></li>
+            <li><a href='nomicon-2016-06-02.letter.pdf'>NOMICON LETTER.PDF</a></li>
+            <li><a href='nomicon-2016-06-02.md'>NOMICON MD</a></li>
+            <li><a href='nomicon-2016-06-02.tex'>NOMICON TEX</a></li>
+            <li><a href='trpl-2016-06-02.a4.pdf'>TRPL A4.PDF</a></li>
+            <li><a href='trpl-2016-06-02.epub'>TRPL EPUB</a></li>
+            <li><a href='trpl-2016-06-02.html'>TRPL HTML</a></li>
+            <li><a href='trpl-2016-06-02.letter.pdf'>TRPL LETTER.PDF</a></li>
+            <li><a href='trpl-2016-06-02.md'>TRPL MD</a></li>
+            <li><a href='trpl-2016-06-02.tex'>TRPL TEX</a></li>
+            </ul>
+            </li>
+            
+            <li>      
+            <h2>2015-09-26</h2>
+            <ul><li><a href='trpl-2015-09-26.a4.pdf'>TRPL A4.PDF</a></li>
+            <li><a href='trpl-2015-09-26.epub'>TRPL EPUB</a></li>
+            <li><a href='trpl-2015-09-26.html'>TRPL HTML</a></li>
+            <li><a href='trpl-2015-09-26.letter.pdf'>TRPL LETTER.PDF</a></li>
+            <li><a href='trpl-2015-09-26.md'>TRPL MD</a></li>
+            <li><a href='trpl-2015-09-26.tex'>TRPL TEX</a></li>
+            </ul>
+            </li>
+            
+            <li>
+            <h2>2015-09-12</h2>
+            <ul><li><a href='nomicon-2015-09-12.a4.pdf'>NOMICON A4.PDF</a></li>
+            <li><a href='nomicon-2015-09-12.epub'>NOMICON EPUB</a></li>
+            <li><a href='nomicon-2015-09-12.html'>NOMICON HTML</a></li>
+            <li><a href='nomicon-2015-09-12.letter.pdf'>NOMICON LETTER.PDF</a></li>
+            <li><a href='nomicon-2015-09-12.md'>NOMICON MD</a></li>
+            <li><a href='nomicon-2015-09-12.tex'>NOMICON TEX</a></li>
+            <li><a href='trpl-2015-09-12.a4.pdf'>TRPL A4.PDF</a></li>
+            <li><a href='trpl-2015-09-12.epub'>TRPL EPUB</a></li>
+            <li><a href='trpl-2015-09-12.html'>TRPL HTML</a></li>
+            <li><a href='trpl-2015-09-12.letter.pdf'>TRPL LETTER.PDF</a></li>
+            <li><a href='trpl-2015-09-12.md'>TRPL MD</a></li>
+            <li><a href='trpl-2015-09-12.tex'>TRPL TEX</a></li>
+            </ul>
+            </li>
+            
+            <li>
+            <h2>2015-07-31</h2>
+            <ul><li><a href='trpl-2015-07-31.a4.pdf'>TRPL A4.PDF</a></li>
+            <li><a href='trpl-2015-07-31.epub'>TRPL EPUB</a></li>
+            <li><a href='trpl-2015-07-31.html'>TRPL HTML</a></li>
+            <li><a href='trpl-2015-07-31.letter.pdf'>TRPL LETTER.PDF</a></li>
+            <li><a href='trpl-2015-07-31.md'>TRPL MD</a></li>
+            <li><a href='trpl-2015-07-31.tex'>TRPL TEX</a></li>
+            </ul>
+            </li>
+            
+            <li>
+            <h2>2015-05-24</h2>
+            <ul><li><a href='trpl-2015-05-24.a4.pdf'>TRPL A4.PDF</a></li>
+            <li><a href='trpl-2015-05-24.epub'>TRPL EPUB</a></li>
+            <li><a href='trpl-2015-05-24.html'>TRPL HTML</a></li>
+            <li><a href='trpl-2015-05-24.letter.pdf'>TRPL LETTER.PDF</a></li>
+            <li><a href='trpl-2015-05-24.md'>TRPL MD</a></li>
+            <li><a href='trpl-2015-05-24.mobi'>TRPL MOBI</a></li>
+            <li><a href='trpl-2015-05-24.tex'>TRPL TEX</a></li>
+            </ul>
+            </li>
+            
+            <li>
+            <h2>2015-05-15</h2>
+            <ul><li><a href='trpl-2015-05-15.epub'>TRPL EPUB</a></li>
+            <li><a href='trpl-2015-05-15.html'>TRPL HTML</a></li>
+            <li><a href='trpl-2015-05-15.md'>TRPL MD</a></li>
+            <li><a href='trpl-2015-05-15.mobi'>TRPL MOBI</a></li>
+            </ul>
+            </li>
+            <li>
+            <h2>2015-05-13</h2>
+            <ul><li><a href='trpl-2015-05-13.epub'>TRPL EPUB</a></li>
+            <li><a href='trpl-2015-05-13.html'>TRPL HTML</a></li>
+            <li><a href='trpl-2015-05-13.md'>TRPL MD</a></li>
+            </ul>
+            </li>
         </ul>
         <footer>
             Made with ♥︎, too much RegEx and <a href="http://pandoc.org/">Pandoc</a> by <a href="http://pascalhertleif.de/">Pascal Hertleif</a>


### PR DESCRIPTION
I have added the iconic rust logo to give it a look of rust right at home..

![screenshot-9](https://cloud.githubusercontent.com/assets/12121575/16389263/be69c344-3cba-11e6-8b89-e6ed98200b17.png)

try it here [gh-page](http://adiultra.github.io/trpl-ebook)

If you want I can write some additional css to give it crazy & simplistic looks.
