### PR TITLE
Fixup options.rs for changes in pandoc arguments

### DIFF
--- a/src/convert_book/options.rs
+++ b/src/convert_book/options.rs
@@ -1,9 +1,9 @@
 pub const RELEASE_DATE: &'static str = "2016-10-01";
 
-pub const MARKDOWN: &'static str = "markdown+grid_tables+pipe_tables-simple_tables+raw_html+implicit_figures+footnotes+intraword_underscores+auto_identifiers-inline_code_attributes";
+pub const MARKDOWN: &'static str = "markdown+smart+grid_tables+pipe_tables-simple_tables+raw_html+implicit_figures+footnotes+intraword_underscores+auto_identifiers-inline_code_attributes";
 
-pub const HTML: &'static str = "--smart --normalize --standalone --self-contained --highlight-style=tango --table-of-contents --section-divs --template=lib/template.html --css=lib/pandoc.css --to=html5";
+pub const HTML: &'static str = "--standalone --self-contained --highlight-style=tango --table-of-contents --section-divs --template=lib/template.html --css=lib/pandoc.css --to=html5";
 
-pub const EPUB: &'static str = "--smart --normalize --standalone --self-contained --highlight-style=tango --epub-stylesheet=lib/epub.css --table-of-contents";
+pub const EPUB: &'static str = "--standalone --self-contained --highlight-style=tango --css=lib/epub.css --table-of-contents";
 
-pub const LATEX: &'static str = "--smart --normalize --standalone --self-contained --highlight-style=tango --chapters --table-of-contents --template=lib/template.tex --latex-engine=xelatex --to=latex";
+pub const LATEX: &'static str = "--standalone --self-contained --highlight-style=tango --top-level-division=chapter --table-of-contents --template=lib/template.tex --pdf-engine=xelatex --to=latex";


### PR DESCRIPTION
Recent pandoc has removed or changed certain arguments, and will fail with the current manner in which pandoc is invoked. Which then causes a panic in libcore/result.rs, and fail.

Fixup the arguments so it works with (at least) pandoc 2.0.6, as shipped by Fedora 28.

This will presumably break with the earlier versions of pandoc.